### PR TITLE
Return on reject.

### DIFF
--- a/src/processKill.js
+++ b/src/processKill.js
@@ -17,7 +17,7 @@ async function unixKill({ inputArray, opts }) {
 			const command = `lsof -i tcp:${input} | grep LISTEN | awk '{print $2}' | xargs kill -9`;
 			exec(command, (err, stdout, stderr) => {
 				if (err) {
-					reject(err);
+					return reject(err);
 				}
 				console.log(`Successfully terminated process running on port ${input}`);
 				resolve();


### PR DESCRIPTION
 This prevents execution that was not meant to executed when an error occurs in the exec method (For example, logging the success message to the console.).