### PR TITLE
Feat/silent-flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ $ kill-port --port 1234
 * `--graceful` kill the process gracefully.
   * **Unix:** Sends a `-15` signal to kill (`SIGTERM`) rather than `-9` (`SIGKILL`)
   * **Win:** Currently no use
+* `--silent` suppresses the output of the command regardless of the result.
 
 ## Compatibility
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kill-port-process",
-	"version": "3.2.1",
+	"version": "3.3.0-0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kill-port-process",
-			"version": "3.2.1",
+			"version": "3.3.0-0",
 			"license": "ISC",
 			"dependencies": {
 				"get-them-args": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "kill-port-process",
-	"version": "3.2.1",
+	"version": "3.3.0-0",
 	"description": "Easily kill hanging processes on ports - on any platform!",
 	"main": "dist/lib/index.js",
 	"bin": {

--- a/src/bin/kill-port-process.ts
+++ b/src/bin/kill-port-process.ts
@@ -30,6 +30,7 @@ interface Args {
 	port?: Ports;
 	unknown?: Ports;
 	graceful?: boolean;
+	silent?: boolean;
 }
 
 function parsePortFromArgs(args: Args) {
@@ -46,6 +47,7 @@ function parsePortFromArgs(args: Args) {
 
 type Flags = {
 	graceful?: boolean;
+	silent?: boolean;
 }
 
 function parseFlagsFromArgs(args: Args): Flags {
@@ -55,16 +57,24 @@ function parseFlagsFromArgs(args: Args): Flags {
 		flags.graceful = true;
 	}
 
+	if (args.silent) {
+		flags.silent = true;
+	}
+
 	return flags;
 }
 
 function formatOptions(flags: Flags): Partial<Options> {
-	const { graceful } = flags;
+	const { graceful, silent } = flags;
 
 	const options: Partial<Options> = {};
 
 	if (graceful) {
 		options.signal = 'SIGTERM';
+	}
+
+	if (silent) {
+		options.silent = silent;
 	}
 
 	return options;

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -13,7 +13,8 @@ export function arrayifyInput(input: any) {
 
 export function mergeOptions(options: Partial<Options>): Options {
 	const defaultOptions: Options = {
-		signal: 'SIGKILL'
+		signal: 'SIGKILL',
+		silent: false
 	};
 
 	return { ...defaultOptions, ...options };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ type Ports = number | number[] | string | string[];
 
 export interface Options {
 	signal: Signal
+	silent: boolean;
 }
 
 export async function killPortProcess(inputPorts: Ports, inputOptions: Partial<Options> = {}) {
@@ -14,11 +15,20 @@ export async function killPortProcess(inputPorts: Ports, inputOptions: Partial<O
 
 	const options = mergeOptions(inputOptions);
 
-	const toNumber = (value: string | number) => Number(value);
-	const ports = arrayifyInput(inputPorts).map(toNumber);
+	try {
 
-	const killer = new Killer(ports);
-	await killer.kill({
-		signal: options.signal
-	})
+		const toNumber = (value: string | number) => Number(value);
+		const ports = arrayifyInput(inputPorts).map(toNumber);
+
+		const killer = new Killer(ports);
+		await killer.kill({
+			signal: options.signal
+		});
+	} catch (error) {
+		if (options.silent) {
+			return;
+		}
+
+		throw error;
+	}
 }


### PR DESCRIPTION
Provide a new flag `silent` to allow intentionally hiding (noisy) error outputs.

Implements https://github.com/hilleer/kill-port-process/issues/97